### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 9 * * *'
     - cron: '0 21 * * *'
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   run_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/zenn-trending-to-bluesky/security/code-scanning/2](https://github.com/aegisfleet/zenn-trending-to-bluesky/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- The `contents: read` permission is needed for checking out the repository.
- The `actions: write` permission is required for uploading artifacts.
- No other permissions appear to be necessary.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
